### PR TITLE
#14. Fix "Permission denied" when executing `gradlew` from tmpfs

### DIFF
--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -39,5 +39,5 @@ docker run \
     --read-only \
     --mount type=bind,src="${input_dir}",dst=/solution \
     --mount type=bind,src="${output_dir}",dst=/output \
-    --mount type=tmpfs,dst=/tmp \
+    --tmpfs /tmp:exec \
     exercism/test-runner "${slug}" /solution /output


### PR DESCRIPTION
`--mount type=tmpfs` is `noexec` by-default and there is no way to change that (as far as I see).