### PR TITLE
🤖 Update `.dockerignore` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,4 @@ tests/
 .gitignore
 .gitattributes
 .dockerignore
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ bin/run-in-docker.sh
 bin/run-tests-in-docker.sh
 tests/
 .git
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ tests/
 .git
 .gitignore
 .gitattributes
+.dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ docs/
 bin/run-in-docker.sh
 bin/run-tests-in-docker.sh
 tests/
+.git

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ bin/run-tests-in-docker.sh
 tests/
 .git
 .gitignore
+.gitattributes


### PR DESCRIPTION
To help both speedup Docker builds _and_ prevent new containers being created when unrelated files changes, this PR adds some rules to the `.dockerignore` file (or add the file when it didn't exist).
See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more information on `.dockerignore` files and what they do.

# Tracking issue

See https://github.com/exercism/exercism/issues/6113
