### PR TITLE
Upgrade to Gradle 8.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # === Build builder image ===
 
-FROM gradle:6.8-jdk11 AS build
+FROM gradle:8.1.1-jdk11 AS build
 
 WORKDIR /home/builder
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,13 +2,13 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     kotlin("jvm") version "1.8.22"
-    id("com.github.johnrengelman.shadow") version "5.2.0"
+    id("com.github.johnrengelman.shadow") version "8.1.1"
     application
 }
 
 repositories {
     mavenLocal()
-    jcenter()
+    mavenCentral()
     maven("https://jitpack.io")
 }
 
@@ -34,7 +34,7 @@ tasks.withType<Test> {
 }
 
 application {
-    mainClassName = "exercism.kotlin.autotests.runner.MainKt"
+    mainClass.set("exercism.kotlin.autotests.runner.MainKt")
 }
 
 tasks.withType<ShadowJar> {

--- a/examples/template/build.gradle.kts
+++ b/examples/template/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/examples/template/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/template/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
#30 suspects that Gradle may be the culprit for poor performances.

Current version of Gradle (6.x) was released in 2019. Performance improvements can be expected with this year version (8.x)

Few breacking changes forced us to modify our configuration:
- `mainClassName` is not supported anymore
- shadowJar needed to be updated because old version relied on some removed Gradle API
- jcenter is deprecated